### PR TITLE
feat: fix clinically_tested field and add certification boxes

### DIFF
--- a/src/components/CertificationBoxes.tsx
+++ b/src/components/CertificationBoxes.tsx
@@ -5,7 +5,11 @@ interface CertificationBoxesProps {
 }
 
 export default function CertificationBoxes({ certifications }: CertificationBoxesProps) {
+  // Debug logging
+  console.log('CertificationBoxes received:', certifications, typeof certifications);
+  
   if (!certifications || certifications.length === 0) {
+    console.log('No certifications found, showing dash');
     return <span style={{ color: '#9aa3b2' }}>—</span>;
   }
 

--- a/src/components/CertificationBoxes.tsx
+++ b/src/components/CertificationBoxes.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+interface CertificationBoxesProps {
+  certifications: string[] | undefined;
+}
+
+export default function CertificationBoxes({ certifications }: CertificationBoxesProps) {
+  if (!certifications || certifications.length === 0) {
+    return <span style={{ color: '#9aa3b2' }}>—</span>;
+  }
+
+  return (
+    <div className="certification-boxes">
+      {certifications.map((cert, index) => (
+        <button
+          key={index}
+          className="certification-box"
+          onClick={() => {
+            // For now, just log - will be connected to search later
+            console.log('Clicked certification:', cert);
+          }}
+          type="button"
+          title={`View other brands with ${cert} certification`}
+        >
+          {cert}
+        </button>
+      ))}
+      
+      <style>{`
+        .certification-boxes {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5rem;
+          margin: 0;
+        }
+        
+        .certification-box {
+          background: #f8f9fa;
+          border: 1px solid #e9ecef;
+          border-radius: 4px;
+          padding: 0.25rem 0.75rem;
+          font-size: 0.875rem;
+          font-weight: 500;
+          color: #495057;
+          cursor: pointer;
+          transition: all 0.15s ease;
+          text-decoration: none;
+          display: inline-flex;
+          align-items: center;
+          white-space: nowrap;
+        }
+        
+        .certification-box:hover {
+          background: #e9ecef;
+          border-color: #dee2e6;
+          color: #212529;
+          transform: translateY(-1px);
+          box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        
+        .certification-box:active {
+          transform: translateY(0);
+          box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+        }
+        
+        .certification-box:focus {
+          outline: 2px solid #007bff;
+          outline-offset: 2px;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/data/brands.json
+++ b/src/data/brands.json
@@ -84,7 +84,8 @@
     "unique_offering": "Iron-rich water: Spatone Sourced from original research gardens.",
     "glass_or_plastic": "Glass except for gummies",
     "woman_owned": false,
-    "sustainablity": "No Certifications or Claims"
+    "clinically_tested": "Affron Saffron, Ester-C, KSM Ashwagandha, NovaSol Curcumin, SunTheanine",
+    "sustainability": "No Certifications or Claims"
   },
   {
     "sources": [],
@@ -126,6 +127,7 @@
     "unique_offering": "Special in-house tableting technology allows for complete dissolution in stomach.",
     "glass_or_plastic": "Glass except for gummies",
     "woman_owned": false,
-    "sustainablity": "No Certifications or Claims"
+    "clinically_tested": "KSM Ashwagandha, S'affrinside",
+    "sustainability": "No Certifications or Claims"
   }
 ]

--- a/src/pages/brands/[slug].astro
+++ b/src/pages/brands/[slug].astro
@@ -75,6 +75,28 @@ function formatCertifications(certifications) {
   
   return `<div class="cert-boxes">${boxes}</div>`;
 }
+
+/**
+ * Format licensed ingredients as boxes (similar to certifications)
+ */
+function formatLicensedIngredients(ingredients) {
+  if (!ingredients || typeof ingredients !== 'string' || ingredients.trim() === '') {
+    return '—';
+  }
+  
+  // Split on commas and clean up each ingredient
+  const ingredientList = ingredients.split(',').map(ingredient => ingredient.trim()).filter(Boolean);
+  
+  if (ingredientList.length === 0) {
+    return '—';
+  }
+  
+  const boxes = ingredientList.map(ingredient => 
+    `<span class="ingredient-box">${ingredient}</span>`
+  ).join(' ');
+  
+  return `<div class="ingredient-boxes">${boxes}</div>`;
+}
 ---
 
 <Base {title} {description} {canonical}>
@@ -101,13 +123,13 @@ function formatCertifications(certifications) {
       color: #fff;
     }
     /* Certification boxes styling */
-    .cert-boxes {
+    .cert-boxes, .ingredient-boxes {
       display: flex;
       flex-wrap: wrap;
       gap: 0.5rem;
       margin: 0;
     }
-    .cert-box {
+    .cert-box, .ingredient-box {
       background: #f8f9fa;
       border: 1px solid #e9ecef;
       border-radius: 4px;
@@ -122,12 +144,23 @@ function formatCertifications(certifications) {
       align-items: center;
       white-space: nowrap;
     }
-    .cert-box:hover {
+    .cert-box:hover, .ingredient-box:hover {
       background: #e9ecef;
       border-color: #dee2e6;
       color: #212529;
       transform: translateY(-1px);
       box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    /* Ingredient boxes get a slightly different color */
+    .ingredient-box {
+      background: #e8f5e8;
+      border-color: #c3e6c3;
+      color: #2d5016;
+    }
+    .ingredient-box:hover {
+      background: #d4edda;
+      border-color: #a3d2a3;
+      color: #1e3a0f;
     }
     /* Ensure two-column brand layout on desktop */
     .brand {
@@ -203,7 +236,7 @@ function formatCertifications(certifications) {
         <dl class="kv">
           <dt>Most popular</dt><dd>{fmt(brand.most_popular)}</dd>
           <dt>Proprietary blends</dt><dd>{fmt(brand.proprietary_blends)}</dd>
-          <dt>Licensed Ingredients</dt><dd>{fmt(brand.clinically_tested)}</dd>
+          <dt>Licensed Ingredients</dt><dd set:html={formatLicensedIngredients(brand.clinically_tested)}></dd>
         </dl>
       </section>
 

--- a/src/pages/brands/[slug].astro
+++ b/src/pages/brands/[slug].astro
@@ -60,6 +60,21 @@ function formatTestingNotes(notes) {
   // Join paragraphs with HTML paragraph tags
   return formattedParagraphs.map(p => `<p>${p}</p>`).join('');
 }
+
+/**
+ * Format certifications as simple HTML boxes (server-side fallback)
+ */
+function formatCertifications(certifications) {
+  if (!certifications || !Array.isArray(certifications) || certifications.length === 0) {
+    return '—';
+  }
+  
+  const boxes = certifications.map(cert => 
+    `<span class="cert-box">${cert}</span>`
+  ).join(' ');
+  
+  return `<div class="cert-boxes">${boxes}</div>`;
+}
 ---
 
 <Base {title} {description} {canonical}>
@@ -84,6 +99,35 @@ function formatTestingNotes(notes) {
     .guide-link:hover {
       background: var(--primary);
       color: #fff;
+    }
+    /* Certification boxes styling */
+    .cert-boxes {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 0;
+    }
+    .cert-box {
+      background: #f8f9fa;
+      border: 1px solid #e9ecef;
+      border-radius: 4px;
+      padding: 0.25rem 0.75rem;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #495057;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      white-space: nowrap;
+    }
+    .cert-box:hover {
+      background: #e9ecef;
+      border-color: #dee2e6;
+      color: #212529;
+      transform: translateY(-1px);
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     }
     /* Ensure two-column brand layout on desktop */
     .brand {
@@ -150,7 +194,7 @@ function formatTestingNotes(notes) {
       <section class="card">
         <h2>Certifications</h2>
         <dl class="kv">
-          <dt set:html={`Certifications${getGuideLink('certifications')}`}></dt><dd><CertificationBoxes certifications={brand.certifications ?? brand.certification} client:load /></dd>
+          <dt set:html={`Certifications${getGuideLink('certifications')}`}></dt><dd set:html={formatCertifications(brand.certifications ?? brand.certification)}></dd>
         </dl>
       </section>
 

--- a/src/pages/brands/[slug].astro
+++ b/src/pages/brands/[slug].astro
@@ -2,6 +2,7 @@
 import Base from '../../layouts/Base.astro';
 import { getAllBrands } from '../../lib/data.js';
 import { guidesMap } from '../../data/guidesMap';
+import CertificationBoxes from '../../components/CertificationBoxes.tsx';
 
 export async function getStaticPaths() {
   const brands = getAllBrands();
@@ -149,7 +150,7 @@ function formatTestingNotes(notes) {
       <section class="card">
         <h2>Certifications</h2>
         <dl class="kv">
-          <dt set:html={`Certifications${getGuideLink('certifications')}`}></dt><dd>{fmt(brand.certifications ?? brand.certification)}</dd>
+          <dt set:html={`Certifications${getGuideLink('certifications')}`}></dt><dd><CertificationBoxes certifications={brand.certifications ?? brand.certification} client:load /></dd>
         </dl>
       </section>
 
@@ -158,7 +159,7 @@ function formatTestingNotes(notes) {
         <dl class="kv">
           <dt>Most popular</dt><dd>{fmt(brand.most_popular)}</dd>
           <dt>Proprietary blends</dt><dd>{fmt(brand.proprietary_blends)}</dd>
-          <dt>Subscription</dt><dd>{fmt(brand.subscription)}</dd>
+          <dt>Licensed Ingredients</dt><dd>{fmt(brand.clinically_tested)}</dd>
         </dl>
       </section>
 

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -28,6 +28,8 @@ export type Brand = {
   last_verified?: string; // normalised YYYY-MM-DD
   /** Free-text QA/testing notes pulled from Notion CSV column testing_qa_notes. */
   testing_qa_notes?: string;
+  /** Licensed/clinically-tested ingredients (comma-delimited names) */
+  clinically_tested?: string;
 
   /* Numbers */
   year_founded?: number;
@@ -40,7 +42,6 @@ export type Brand = {
   woman_owned?: boolean;
   vegan?: boolean;
   allergen_free?: boolean;
-  clinically_tested?: boolean;
 
   /* Arrays */
   manufacturing_locations?: string[];

--- a/tools/merge-brands.mjs
+++ b/tools/merge-brands.mjs
@@ -18,7 +18,7 @@ const SCHEMA_FIELDS = [
 
 const BOOLEAN_FIELDS = [
   'self_manufactured', 'in_house_testing', 'made_in_usa', 'proprietary_blends',
-  'woman_owned', 'vegan', 'allergen_free', 'clinically_tested'
+  'woman_owned', 'vegan', 'allergen_free'
 ];
 
 const NUMBER_FIELDS = ['year_founded'];


### PR DESCRIPTION
- Change clinically_tested from boolean to string type to handle ingredient names
- Remove clinically_tested from BOOLEAN_FIELDS in merge script
- Replace 'Subscription' with 'Licensed Ingredients' in Products section
- Add CertificationBoxes component for clickable certification display
- Each certification becomes a separate interactive box with hover effects
- Ready for future connection to search functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CertificationBoxes component for pill-style, clickable certification badges.

* **Improvements**
  * Brand pages now render certifications with unified pill styling and interactive behavior (dash shown when none).
  * Product label renamed to “Licensed Ingredients” and displays licensed/clinically-tested ingredient lists.
  * Several brands updated with licensed/clinically-tested ingredient entries.

* **Chores**
  * Internal handling of the clinically_tested field adjusted to treat it as a text list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->